### PR TITLE
move dropdown state to item component

### DIFF
--- a/src/pages/ToDo/ToDo.jsx
+++ b/src/pages/ToDo/ToDo.jsx
@@ -112,12 +112,6 @@ class ToDo extends React.Component {
     })
   }
 
-  handleDropDown = (i) => {
-    const new_todo = this.state.todo.slice();
-    new_todo[i].isMenuOpen = !new_todo[i].isMenuOpen;
-    this.setState({todo:new_todo});
-  }
-
   handleDelete = (id, index) => {
     const new_todo = this.state.todo.slice();
     deleteTask(id)
@@ -143,7 +137,6 @@ class ToDo extends React.Component {
           list={this.state.todo}
           show={this.state.show}
           onChange={this.handleCheck}
-          handleDropDown={this.handleDropDown}
           onDelete={this.handleDelete}
         />
         <Toggle

--- a/src/pages/ToDo/ToDoList.jsx
+++ b/src/pages/ToDo/ToDoList.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import ToDoListItem from './ToDoListItem';
 
 const ToDoList = (props) => {
-  const { list, onChange, show, handleDropDown, onDelete } = props;
+  const { list, onChange, show, onDelete } = props;
   return(
     <ul>
       {list.sort(
@@ -29,7 +29,6 @@ const ToDoList = (props) => {
             text={data.content}
             isComplete={data.completed}
             onChange={() => onChange(data.id, data.completed)}
-            handleDropDown={() => handleDropDown(index)}
             isMenuOpen={data.isMenuOpen}
             onDelete={() => onDelete(data.id, index)}
             flip={data.flip}

--- a/src/pages/ToDo/ToDoListItem.jsx
+++ b/src/pages/ToDo/ToDoListItem.jsx
@@ -2,6 +2,14 @@ import React from 'react';
 import { Link } from 'react-router-dom';
 
 class ToDoListItem extends React.Component {
+  constructor(props){
+    super(props);
+
+    this.state = {
+      open: false,
+    }
+  }
+
   componentWillReceiveProps(nextProps) {
     if (!this.props.isComplete && nextProps.isComplete) {
       window.requestAnimationFrame(() => {
@@ -14,10 +22,14 @@ class ToDoListItem extends React.Component {
     }
   }
 
+  handleDropDown = () => {
+    this.setState({ open: !this.state.open });
+  }
+
   render() {
-    const {isComplete,id,onChange,text,handleDropDown,isMenuOpen,onDelete,flip} = this.props;
+    const {isComplete, id, onChange, text, isMenuOpen, onDelete, flip} = this.props;
     const isCompleteClass = isComplete ? 'complete' : 'incomplete';
-    const isMenuOpenClass = isMenuOpen ? 'open' : 'closed';
+    const isMenuOpenClass = this.state.open ? 'open' : 'closed';
 
     return(
       <li className={ isCompleteClass + ' todo_item'}>
@@ -26,7 +38,7 @@ class ToDoListItem extends React.Component {
           {text}
         </label>
         <div className={isMenuOpenClass + ' drop_down'}>
-          <button className="toggle_drop"  onClick={handleDropDown}></button>
+          <button className="toggle_drop" onClick={this.handleDropDown}></button>
           <div className="menu">
             <Link className="btn" to={`/task/${id}`}>See Details</Link>
             <button onClick={onDelete} className="delete btn">Delete</button>


### PR DESCRIPTION
Hi @natemecham, I would move the drop down state to the item component itself and keep it contained there. Reason being this state only needs to be known to the item itself. No other components need to know about this. So the handling logic and the state should be in the item component.

You don't have to add the state logic to a redux store because the open state of each item isn't needed by any other component across the app. Redux store should be used to store data that is needed by multiple components across the app. Such as login status, tasks, etc. Redux store should be used as a single source of truth, so that different components rendered from the same data can be consistent across the app.